### PR TITLE
Rich text in content area is always well-formatted.

### DIFF
--- a/Assets/Scripts/Main/States/Game/View/ContentView.cs
+++ b/Assets/Scripts/Main/States/Game/View/ContentView.cs
@@ -46,7 +46,7 @@ public class ContentView : StoryElementView {
 		textTyper = new TypedText();
 		textTyper.OnTypeText += OnTypeText;
 		textTyper.OnCompleteTyping += CompleteTyping;
-		textTyper.TypeText(content, textTyperSettings);
+		textTyper.TypeText(richText.plainText, textTyperSettings);
 	}
 
 	void OnTypeText (string newText) {

--- a/Assets/Scripts/Main/States/Game/View/ContentView.cs
+++ b/Assets/Scripts/Main/States/Game/View/ContentView.cs
@@ -4,6 +4,7 @@ using System.Collections;
 public class ContentView : StoryElementView {
 
 	public TypedText textTyper;
+	private RichTextSubstring richText;
 
 	public Color driedColor;
 	public Color wetColor;
@@ -41,6 +42,7 @@ public class ContentView : StoryElementView {
 			textTyperSettings.defaultTypeDelay = new TypedText.RandomTimeDelay(0.03f,0.0425f);
 		}
 
+		richText = new RichTextSubstring (content);
 		textTyper = new TypedText();
 		textTyper.OnTypeText += OnTypeText;
 		textTyper.OnCompleteTyping += CompleteTyping;
@@ -48,7 +50,7 @@ public class ContentView : StoryElementView {
 	}
 
 	void OnTypeText (string newText) {
-		text.text = textTyper.text;
+		text.text = richText.Substring(0, textTyper.text.Length);
 		if(newText != " ")
 			AudioClipDatabase.Instance.PlayKeySound ();
 	}

--- a/Assets/Scripts/Tests.meta
+++ b/Assets/Scripts/Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 650b071a857aba645ad4b962c94f028b
+folderAsset: yes
+timeCreated: 1462020040
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/Editor.meta
+++ b/Assets/Scripts/Tests/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8fb24acc288415d4a89ed37fe45f7092
+folderAsset: yes
+timeCreated: 1462020049
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs
+++ b/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs
@@ -11,12 +11,12 @@ public class RichTextSubstringTests {
 	public void SubstringReturnsWellFormattedRichText() {
 		RichTextSubstring rts = new RichTextSubstring("<i>foo</i> bar");
 
-		Assert.AreEqual ("<i>f</i>", rts.Substring (1));
-		Assert.AreEqual ("<i>fo</i>", rts.Substring (2));
-		Assert.AreEqual ("<i>foo</i>", rts.Substring (3));
-		Assert.AreEqual ("<i>foo</i> ", rts.Substring (4));
-		Assert.AreEqual ("<i>foo</i> b", rts.Substring (5));
-		Assert.AreEqual ("<i>foo</i> ba", rts.Substring (6));
-		Assert.AreEqual ("<i>foo</i> bar", rts.Substring (7));
+		Assert.AreEqual ("<i>f</i>", rts.Substring (0, 1));
+		Assert.AreEqual ("<i>fo</i>", rts.Substring (0, 2));
+		Assert.AreEqual ("<i>foo</i>", rts.Substring (0, 3));
+		Assert.AreEqual ("<i>foo</i> ", rts.Substring (0, 4));
+		Assert.AreEqual ("<i>foo</i> b", rts.Substring (0, 5));
+		Assert.AreEqual ("<i>foo</i> ba", rts.Substring (0, 6));
+		Assert.AreEqual ("<i>foo</i> bar", rts.Substring (0, 7));
 	}
 }

--- a/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs
+++ b/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs
@@ -18,5 +18,9 @@ public class RichTextSubstringTests {
 		Assert.AreEqual ("<i>foo</i> b", rts.Substring (0, 5));
 		Assert.AreEqual ("<i>foo</i> ba", rts.Substring (0, 6));
 		Assert.AreEqual ("<i>foo</i> bar", rts.Substring (0, 7));
+
+		Assert.AreEqual ("<i>oo</i>", rts.Substring (1, 2));
+		Assert.AreEqual ("<i>o</i>", rts.Substring (1, 1));
+		Assert.AreEqual ("<i>o</i> ba", rts.Substring (2, 4));
 	}
 }

--- a/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs
+++ b/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+
+public class RichTextSubstringTests {
+	[Test]
+	public void ItSetsPlainText () {
+		RichTextSubstring rts = new RichTextSubstring("<i>foo</i> bar");
+		Assert.AreEqual ("foo bar", rts.plainText);
+	}
+
+	[Test]
+	public void SubstringReturnsWellFormattedRichText() {
+		RichTextSubstring rts = new RichTextSubstring("<i>foo</i> bar");
+
+		Assert.AreEqual ("<i>f</i>", rts.Substring (1));
+		Assert.AreEqual ("<i>fo</i>", rts.Substring (2));
+		Assert.AreEqual ("<i>foo</i>", rts.Substring (3));
+		Assert.AreEqual ("<i>foo</i> ", rts.Substring (4));
+		Assert.AreEqual ("<i>foo</i> b", rts.Substring (5));
+		Assert.AreEqual ("<i>foo</i> ba", rts.Substring (6));
+		Assert.AreEqual ("<i>foo</i> bar", rts.Substring (7));
+	}
+}

--- a/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs.meta
+++ b/Assets/Scripts/Tests/Editor/RichTextSubstringTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1efa39f728163e742b38aec9d9e3887e
+timeCreated: 1462020915
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/RichTextSubstring.cs
+++ b/Assets/Scripts/Utils/RichTextSubstring.cs
@@ -25,7 +25,11 @@
 		}
 	}
 
-	public string Substring(int length) {
+	public string Substring(int startIndex, int length) {
+		if (startIndex != 0) {
+			// We might add support for this case later, but for now, throw an error.
+			throw new System.InvalidOperationException ("startIndex must be 0 for now, sorry!");
+		}
 		return string.Empty;
 	}
 }

--- a/Assets/Scripts/Utils/RichTextSubstring.cs
+++ b/Assets/Scripts/Utils/RichTextSubstring.cs
@@ -3,33 +3,52 @@
 	public readonly string richText;
 	public readonly string plainText;
 
+	private bool[] plainTextItalicState;
+
+	private const string OPEN_ITALIC_TAG = "<i>";
+	private const string CLOSE_ITALIC_TAG = "</i>";
+
 	public RichTextSubstring (string richText) {
 		this.richText = richText;
-		this.plainText = string.Empty;
+		plainTextItalicState = new bool[richText.Length];
+		plainText = string.Empty;
 
-		bool isInTag = false;
+		bool isItalic = false;
 
-		for (int i = 0; i < richText.Length; i++) {
-			char c = richText [i];
-			if (isInTag) {
-				if (c == '>') {
-					isInTag = false;
-				}
+		for (int i = 0; i < richText.Length;) {
+			if (!isItalic && richText.Substring(i).StartsWith(OPEN_ITALIC_TAG)) {
+				isItalic = true;
+				i += OPEN_ITALIC_TAG.Length;
+			} else if (isItalic && richText.Substring(i).StartsWith(CLOSE_ITALIC_TAG)) {
+				isItalic = false;
+				i += CLOSE_ITALIC_TAG.Length;
 			} else {
-				if (c == '<') {
-					isInTag = true;
-				} else {
-					this.plainText += c;
-				}
+				plainTextItalicState [plainText.Length] = isItalic;
+				plainText += richText[i];
+				i++;
 			}
 		}
 	}
 
 	public string Substring(int startIndex, int length) {
-		if (startIndex != 0) {
-			// We might add support for this case later, but for now, throw an error.
-			throw new System.InvalidOperationException ("startIndex must be 0 for now, sorry!");
+		string result = string.Empty;
+		bool isItalic = false;
+
+		for (int i = startIndex; i < startIndex + length; i++) {
+			if (isItalic && !plainTextItalicState [i]) {
+				isItalic = false;
+				result += CLOSE_ITALIC_TAG;
+			} else if (!isItalic && plainTextItalicState [i]) {
+				isItalic = true;
+				result += OPEN_ITALIC_TAG;
+			}
+			result += plainText [i];
 		}
-		return string.Empty;
+
+		if (isItalic) {
+			result += CLOSE_ITALIC_TAG;
+		}
+
+		return result;
 	}
 }

--- a/Assets/Scripts/Utils/RichTextSubstring.cs
+++ b/Assets/Scripts/Utils/RichTextSubstring.cs
@@ -1,0 +1,31 @@
+﻿public class RichTextSubstring
+{
+	public readonly string richText;
+	public readonly string plainText;
+
+	public RichTextSubstring (string richText) {
+		this.richText = richText;
+		this.plainText = string.Empty;
+
+		bool isInTag = false;
+
+		for (int i = 0; i < richText.Length; i++) {
+			char c = richText [i];
+			if (isInTag) {
+				if (c == '>') {
+					isInTag = false;
+				}
+			} else {
+				if (c == '<') {
+					isInTag = true;
+				} else {
+					this.plainText += c;
+				}
+			}
+		}
+	}
+
+	public string Substring(int length) {
+		return string.Empty;
+	}
+}

--- a/Assets/Scripts/Utils/RichTextSubstring.cs.meta
+++ b/Assets/Scripts/Utils/RichTextSubstring.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 717d1003f43ead24f8d2d6465083f84a
+timeCreated: 1462020409
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is an attempt to fix #1.

Here's some rich text in the game before the fix:

![broken](https://cloud.githubusercontent.com/assets/124687/14936934/b7ca6588-0ec6-11e6-8ad7-9ffc56f0d1a9.gif)

And here's the same text after the fix:

![fixed](https://cloud.githubusercontent.com/assets/124687/14936937/bda7851c-0ec6-11e6-9790-d30210c978b8.gif)

My strategy to fix it is a bit odd, maybe.

Basically, the `TypedText` class remains unchanged; it's really built to handle plain text and making it support rich text would add a lot of complexity to the class and possibly break other things that use it.

So instead, I added a new class called `RichTextSubstring`. It does two things:
- It strips out the rich text markup from a string and exposes it via a `plainText` property. `ContentView.LayoutText()` passes this to `TypedText.TypeText()`, guaranteeing that a `TypedText` instance will only ever process plain text. This means that e.g. a `<i>` will never factor in to the timing algorithm used to simulate typing.
- It also exposes a `Substring()` method that can be used to obtain _well-formatted_ substrings of the original rich text--see the [test suite](https://github.com/inkle/the-intercept/pull/3/files#diff-740e7f6e64f5f3affaf468a40d6847f0) for concrete examples of what this actually means. The indices passed in to this method are based on the plain-text representation of the string, not the rich text. `ContentView.OnTypeText()` uses this to convert the plain-text representation of the text given to it by `TypedText` into rich text.

Currently, `RichTextSubstring` is only made to process the markup that The Intercept's Ink script uses--which is to say, it only really understands `<i>` and `</i>`, rather than [Unity's full rich text specification](http://docs.unity3d.com/Manual/StyledText.html). Support for more tags could be added in the future, though.

I also added a basic test suite for `RichTextSubstring`, but I should note that this might mean the project no longer compiles with older versions of Unity, as [NUnit was added in Unity 5.3](http://blogs.unity3d.com/2015/12/08/unity-5-3-all-new-features-and-more-platforms/)... Is that ok?
